### PR TITLE
Added new feature that allow glob pattern passing and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ accessibility of each url.
 - Support for parallelization for the tool to run efficiently
 
 - Only headers are requested when the urls are being checked. 
+- Allows passing glob pattern as an argument
+  ```go
+    ./urlChecker -g [glob-pattern]
+  ```
+  For example,
+  ```go
+    ./urlChecker -g *.txt
+  ```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/fatih/color v1.9.0
+	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
 	mvdan.cc/xurls v1.1.0
 	mvdan.cc/xurls/v2 v2.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4 h1:NK3O7S5FRD/wj7ORQ5C3Mx1STpyEMuFe+/F0Lakd1Nk=
+github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4/go.mod h1:FqD3ES5hx6zpzDainDaHgkTIqrPaI9uX4CVWqYZoQjY=
 github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=

--- a/urlChecker.go
+++ b/urlChecker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mb0/glob"
 	"mvdan.cc/xurls/v2"
 )
 
@@ -81,6 +83,8 @@ func checkURL(urls []string) {
 }
 
 func main() {
+	globFlag := flag.Bool("g", false, "Glob pattern")
+	flag.Parse()
 	//deal with non-file path, giving usage message
 	if len(os.Args) == 1 {
 		fmt.Println("help/usage message: To run this program, please pass an argument to it,i.e.: go run urlChecker.go urls.txt")
@@ -89,6 +93,35 @@ func main() {
 		//feature of checking version
 		if string(os.Args[1]) == "-v" || string(os.Args[1]) == "-version" || string(os.Args[1]) == "/v" {
 			fmt.Println("  *****  urlChecker Version 0.1  *****  ")
+			return
+		}
+
+		if *globFlag {
+			//Assign the glob pattern provided to a local variable
+			pattern := flag.Args()[0]
+			//Read all files in the current directory
+			files, _ := ioutil.ReadDir(".")
+			//Create a globber object
+			globber, _ := glob.New(glob.Default())
+			//Loop through all files
+			for _, file := range files {
+				//Check if the file name match the glob pattern provided
+				matched, _ := globber.Match(pattern, file.Name())
+				//If matched then run the url check on that file
+				if matched {
+					//open file and read it
+					content, err := ioutil.ReadFile(file.Name())
+					if err != nil {
+						log.Fatal(err)
+					}
+					textContent := string(content)
+
+					fmt.Println(">>  ***** UrlChecker is working now...... *****  <<")
+					fmt.Println("--------------------------------------------------------------------------------------------------")
+					//call functions to check the availability of each url
+					checkURL(extractURL(textContent))
+				}
+			}
 			return
 		}
 


### PR DESCRIPTION
Hi Isabella,

I have completed the new feature that allows users to pass a glob pattern as an argument.

For example:
urlChecker -g *.txt 
will search for all .txt files and do the url checks on them.